### PR TITLE
CI: Update dependabot config with missing tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     interval: "weekly"
 
 - package-ecosystem: "gomod"
+  directory: "/dummymetron"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "gomod"
   directory: "/echo"
   schedule:
     interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
     interval: "weekly"
 
 - package-ecosystem: "gomod"
+  directory: "/envelopeemitter"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "gomod"
   directory: "/https_drain"
   schedule:
     interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     interval: "weekly"
 
 - package-ecosystem: "gomod"
+  directory: "/echo"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "gomod"
   directory: "/emitter"
   schedule:
     interval: "weekly"


### PR DESCRIPTION
Tools that we should be updating:
- `echo`
- `envelopeemitter`
- `dummymetron`