### PR TITLE
CI: drop --auto from Dependabot merge step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
               pull_number: context.payload.pull_request.number,
               event: 'APPROVE'
             });
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Merge Dependabot PRs
+        run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Symptom**: Every Dependabot PR shows the Auto‑Merge Dependabot PRs job as failing with "GraphQL: Pull request is in unstable status (enablePullRequestAutoMerge)". PRs still merge eventually but the red X is noisy.

**Problem:** The `--auto` flag is meant to defer the merge until required status checks pass, but this repo's master branch has no required checks configured in branch protection, which causes GitHub to reject `enablePullRequestAutoMerge` with "Pull request is in unstable status" on every Dependabot PR.

**Why can --auto be safely removed?**

The auto-merge job already gates on `needs: [unit-test, lint]`, so by the time it runs, all CI checks have passed.

**Why not just use required status checks of GH?**

This would require us to maintain the list of required status checks, which is currently 54 items long:

  - 27 Unit Test (<dir>) entries
  - 27 Lint (<dir>) entries

**Solution**: Switching to a plain `gh pr merge --merge` removes the "Pull request is in unstable status" failure without changing intended behavior.